### PR TITLE
Add admin panel for user role management

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@ Prototype for an AI-powered accounting platform. This repository currently
 contains a minimal FastAPI backend demonstrating role based access control and
 basic internationalization with Hebrew RTL support.
 
+The application now includes an admin panel for managing user permissions.
+Users are identified via the `X-User` header. Administrators can assign roles
+with `PUT /admin/users/{username}` and list current assignments using
+`GET /admin/users`. Supported roles include `admin`, `accountant`,
+`bookkeeper` (tax consultants/account managers) and `client`.
+
 ## Development
 
 ```bash

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,7 @@
 from fastapi import Depends, FastAPI, Query
+from pydantic import BaseModel
 
-from .dependencies import Role, role_required
+from .dependencies import Role, role_required, user_roles
 from . import i18n
 
 app = FastAPI(title="Theador")
@@ -15,6 +16,25 @@ async def greeting(lang: str = Query("en")):
 @app.get("/admin/ping", dependencies=[Depends(role_required(Role.ADMIN))])
 async def admin_ping():
     return {"status": "admin pong"}
+
+
+class UserRole(BaseModel):
+    role: Role
+
+
+@app.get("/admin/users", dependencies=[Depends(role_required(Role.ADMIN))])
+async def list_users():
+    return {
+        "users": [
+            {"username": username, "role": role} for username, role in user_roles.items()
+        ]
+    }
+
+
+@app.put("/admin/users/{username}", dependencies=[Depends(role_required(Role.ADMIN))])
+async def set_user_role(username: str, user_role: UserRole):
+    user_roles[username] = user_role.role
+    return {"username": username, "role": user_role.role}
 
 
 @app.get(

--- a/backend/tests/test_rbac.py
+++ b/backend/tests/test_rbac.py
@@ -1,5 +1,5 @@
 import pytest
-from httpx import AsyncClient, ASGITransport
+from httpx import ASGITransport, AsyncClient
 
 from backend.app.main import app
 
@@ -8,7 +8,7 @@ from backend.app.main import app
 async def test_admin_access():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
-        resp = await ac.get("/admin/ping", headers={"X-Role": "admin"})
+        resp = await ac.get("/admin/ping", headers={"X-User": "admin"})
     assert resp.status_code == 200
     assert resp.json()["status"] == "admin pong"
 
@@ -17,5 +17,27 @@ async def test_admin_access():
 async def test_admin_denied_for_client():
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
-        resp = await ac.get("/admin/ping", headers={"X-Role": "client"})
+        await ac.put(
+            "/admin/users/bob",
+            json={"role": "client"},
+            headers={"X-User": "admin"},
+        )
+        resp = await ac.get("/admin/ping", headers={"X-User": "bob"})
     assert resp.status_code == 403
+
+
+@pytest.mark.anyio
+async def test_role_assignment():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        await ac.put(
+            "/admin/users/carla",
+            json={"role": "accountant"},
+            headers={"X-User": "admin"},
+        )
+        resp = await ac.get("/accountant/ping", headers={"X-User": "carla"})
+        assert resp.status_code == 200
+        users_resp = await ac.get("/admin/users", headers={"X-User": "admin"})
+        assert {"username": "carla", "role": "accountant"} in users_resp.json()[
+            "users"
+        ]


### PR DESCRIPTION
## Summary
- maintain an in-memory store for user roles
- expose admin endpoints to assign and list user roles
- switch authentication to X-User header and document the admin panel

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68985dc87184832d989521c345436d91