### PR TITLE
Add in-memory client management and demo frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,17 @@ with `PUT /admin/users/{username}` and list current assignments using
 `GET /admin/users`. Supported roles include `admin`, `accountant`,
 `bookkeeper` (tax consultants/account managers) and `client`.
 
+The backend also provides in-memory endpoints for managing clients:
+
+- `POST /clients` – create a client and assign a bookkeeper/accountant.
+- `GET /clients` and `GET /clients/{id}` – list accessible clients and view
+  details.
+- `POST /clients/{id}/notes` / `GET /clients/{id}/notes` – bookkeepers or
+  accountants can leave notes for a client to read.
+- `POST /clients/{id}/transactions` – record income or expenses.
+- `GET /clients/{id}/summary` – view totals, a simple tax estimate and an
+  expense breakdown (salary vs. other).
+
 ## Development
 
 ```bash

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,10 +1,79 @@
-from fastapi import Depends, FastAPI, Query
+from datetime import date, datetime
+from typing import Dict, List, Literal, Optional
+
+from fastapi import Depends, FastAPI, HTTPException, Query, status
 from pydantic import BaseModel
 
 from .dependencies import Role, role_required, user_roles
 from . import i18n
 
 app = FastAPI(title="Theador")
+
+
+class Client(BaseModel):
+    id: int
+    username: str
+    name: str
+    bookkeeper: str | None = None
+    accountant: str | None = None
+
+
+class ClientCreate(BaseModel):
+    username: str
+    name: str
+    bookkeeper: str | None = None
+    accountant: str | None = None
+
+
+class Note(BaseModel):
+    author: str
+    text: str
+    timestamp: datetime
+
+
+class NoteCreate(BaseModel):
+    text: str
+
+
+class Transaction(BaseModel):
+    id: int
+    type: Literal["income", "expense"]
+    amount: float
+    category: str
+    date: date
+
+
+class TransactionCreate(BaseModel):
+    type: Literal["income", "expense"]
+    amount: float
+    category: str
+    date: Optional[date] = None
+
+
+clients: Dict[int, Client] = {}
+client_notes: Dict[int, List[Note]] = {}
+client_transactions: Dict[int, List[Transaction]] = {}
+next_client_id = 1
+next_transaction_id = 1
+
+
+def get_client_or_404(client_id: int) -> Client:
+    client = clients.get(client_id)
+    if client is None:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Client not found")
+    return client
+
+
+def ensure_client_access(client: Client, username: str, role: Role) -> None:
+    if role == Role.ADMIN:
+        return
+    if role == Role.CLIENT and client.username == username:
+        return
+    if role == Role.BOOKKEEPER and client.bookkeeper == username:
+        return
+    if role == Role.ACCOUNTANT and client.accountant == username:
+        return
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Not enough permissions")
 
 
 @app.get("/greeting")
@@ -55,3 +124,144 @@ async def accountant_ping():
 )
 async def client_ping():
     return {"status": "client pong"}
+
+
+@app.post(
+    "/clients",
+)
+async def create_client(
+    client_in: ClientCreate,
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER)
+    ),
+):
+    global next_client_id
+    username, _role = user
+    client_id = next_client_id
+    next_client_id += 1
+    client = Client(id=client_id, **client_in.dict())
+    clients[client_id] = client
+    user_roles.setdefault(client_in.username, Role.CLIENT)
+    return client
+
+
+@app.get("/clients")
+async def list_clients(
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER, Role.CLIENT)
+    )
+):
+    username, role = user
+    result = []
+    for c in clients.values():
+        if role == Role.ADMIN:
+            result.append(c)
+        elif role == Role.ACCOUNTANT and c.accountant == username:
+            result.append(c)
+        elif role == Role.BOOKKEEPER and c.bookkeeper == username:
+            result.append(c)
+        elif role == Role.CLIENT and c.username == username:
+            result.append(c)
+    return {"clients": result}
+
+
+@app.get("/clients/{client_id}")
+async def get_client(
+    client_id: int,
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER, Role.CLIENT)
+    ),
+):
+    username, role = user
+    client = get_client_or_404(client_id)
+    ensure_client_access(client, username, role)
+    return client
+
+
+@app.post("/clients/{client_id}/notes")
+async def add_note(
+    client_id: int,
+    note: NoteCreate,
+    user: tuple[str, Role] = Depends(role_required(Role.ACCOUNTANT, Role.BOOKKEEPER)),
+):
+    username, role = user
+    client = get_client_or_404(client_id)
+    ensure_client_access(client, username, role)
+    note_obj = Note(author=username, text=note.text, timestamp=datetime.utcnow())
+    client_notes.setdefault(client_id, []).append(note_obj)
+    return note_obj
+
+
+@app.get("/clients/{client_id}/notes")
+async def list_notes(
+    client_id: int,
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER, Role.CLIENT)
+    ),
+):
+    username, role = user
+    client = get_client_or_404(client_id)
+    ensure_client_access(client, username, role)
+    return {"notes": client_notes.get(client_id, [])}
+
+
+@app.post("/clients/{client_id}/transactions")
+async def add_transaction(
+    client_id: int,
+    tx: TransactionCreate,
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER, Role.CLIENT)
+    ),
+):
+    username, role = user
+    client = get_client_or_404(client_id)
+    ensure_client_access(client, username, role)
+    global next_transaction_id
+    transaction = Transaction(
+        id=next_transaction_id,
+        date=tx.date or date.today(),
+        **tx.dict(exclude={"date"}),
+    )
+    next_transaction_id += 1
+    client_transactions.setdefault(client_id, []).append(transaction)
+    return transaction
+
+
+@app.get("/clients/{client_id}/transactions")
+async def list_transactions(
+    client_id: int,
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER, Role.CLIENT)
+    ),
+):
+    username, role = user
+    client = get_client_or_404(client_id)
+    ensure_client_access(client, username, role)
+    return {"transactions": client_transactions.get(client_id, [])}
+
+
+@app.get("/clients/{client_id}/summary")
+async def client_summary(
+    client_id: int,
+    user: tuple[str, Role] = Depends(
+        role_required(Role.ADMIN, Role.ACCOUNTANT, Role.BOOKKEEPER, Role.CLIENT)
+    ),
+):
+    username, role = user
+    client = get_client_or_404(client_id)
+    ensure_client_access(client, username, role)
+    txs = client_transactions.get(client_id, [])
+    total_income = sum(t.amount for t in txs if t.type == "income")
+    total_expenses = sum(t.amount for t in txs if t.type == "expense")
+    salary_expenses = sum(
+        t.amount for t in txs if t.type == "expense" and t.category == "salary"
+    )
+    other_expenses = total_expenses - salary_expenses
+    income_tax = total_income * 0.2
+    return {
+        "total_income": total_income,
+        "total_expenses": total_expenses,
+        "income_tax": income_tax,
+        "salary_expenses": salary_expenses,
+        "other_expenses": other_expenses,
+    }

--- a/backend/tests/test_clients.py
+++ b/backend/tests/test_clients.py
@@ -1,0 +1,112 @@
+import pytest
+from httpx import ASGITransport, AsyncClient
+
+from backend.app import main as main_app
+from backend.app.dependencies import Role, user_roles
+
+
+@pytest.mark.anyio
+async def test_client_note_and_summary():
+    user_roles.clear()
+    user_roles["admin"] = Role.ADMIN
+    main_app.clients.clear()
+    main_app.client_notes.clear()
+    main_app.client_transactions.clear()
+    main_app.next_client_id = 1
+    main_app.next_transaction_id = 1
+
+    transport = ASGITransport(app=main_app.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        await ac.put(
+            "/admin/users/bk",
+            json={"role": "bookkeeper"},
+            headers={"X-User": "admin"},
+        )
+        await ac.put(
+            "/admin/users/ac",
+            json={"role": "accountant"},
+            headers={"X-User": "admin"},
+        )
+        resp = await ac.post(
+            "/clients",
+            json={
+                "username": "cl",
+                "name": "Client One",
+                "bookkeeper": "bk",
+                "accountant": "ac",
+            },
+            headers={"X-User": "bk"},
+        )
+        client_id = resp.json()["id"]
+
+        await ac.post(
+            f"/clients/{client_id}/transactions",
+            json={"type": "income", "amount": 1000, "category": "sales"},
+            headers={"X-User": "cl"},
+        )
+        await ac.post(
+            f"/clients/{client_id}/transactions",
+            json={"type": "expense", "amount": 300, "category": "salary"},
+            headers={"X-User": "bk"},
+        )
+        await ac.post(
+            f"/clients/{client_id}/transactions",
+            json={"type": "expense", "amount": 200, "category": "office"},
+            headers={"X-User": "bk"},
+        )
+
+        await ac.post(
+            f"/clients/{client_id}/notes",
+            json={"text": "please review"},
+            headers={"X-User": "bk"},
+        )
+
+        notes_resp = await ac.get(
+            f"/clients/{client_id}/notes", headers={"X-User": "cl"}
+        )
+        assert notes_resp.status_code == 200
+        assert notes_resp.json()["notes"][0]["text"] == "please review"
+
+        summary_resp = await ac.get(
+            f"/clients/{client_id}/summary", headers={"X-User": "cl"}
+        )
+        data = summary_resp.json()
+        assert data["total_income"] == 1000
+        assert data["total_expenses"] == 500
+        assert data["salary_expenses"] == 300
+        assert data["other_expenses"] == 200
+
+
+@pytest.mark.anyio
+async def test_bookkeeper_access_control():
+    user_roles.clear()
+    user_roles["admin"] = Role.ADMIN
+    main_app.clients.clear()
+    main_app.client_notes.clear()
+    main_app.client_transactions.clear()
+    main_app.next_client_id = 1
+    main_app.next_transaction_id = 1
+
+    transport = ASGITransport(app=main_app.app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as ac:
+        await ac.put(
+            "/admin/users/bk1",
+            json={"role": "bookkeeper"},
+            headers={"X-User": "admin"},
+        )
+        await ac.put(
+            "/admin/users/bk2",
+            json={"role": "bookkeeper"},
+            headers={"X-User": "admin"},
+        )
+        resp = await ac.post(
+            "/clients",
+            json={"username": "c1", "name": "Client1", "bookkeeper": "bk1"},
+            headers={"X-User": "bk1"},
+        )
+        client_id = resp.json()["id"]
+
+        resp_forbidden = await ac.get(
+            f"/clients/{client_id}", headers={"X-User": "bk2"}
+        )
+        assert resp_forbidden.status_code == 403

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,7 @@
+# Frontend
+
+This folder contains a tiny static HTML page demonstrating how a client could
+fetch their financial summary from the FastAPI backend.
+
+Serve `index.html` with any static file server while the backend is running and
+adjust the `X-User` header as needed.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Theador</title>
+</head>
+<body>
+  <h1>Theador Client Dashboard</h1>
+  <div id="content">Loading...</div>
+  <script>
+  async function loadSummary() {
+    try {
+      const resp = await fetch('/clients/1/summary', {headers: {'X-User': 'cl'}});
+      const data = await resp.json();
+      document.getElementById('content').textContent = JSON.stringify(data);
+    } catch (e) {
+      document.getElementById('content').textContent = 'Error loading summary';
+    }
+  }
+  loadSummary();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- implement in-memory client, note, and transaction endpoints with role-based access control
- expose simple HTML frontend example showing a client summary
- add tests covering client workflow and permissions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898657607c0832d84386aa73f75fdb0